### PR TITLE
Feature title

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "phosphor-properties": "^2.0.0",
     "phosphor-signaling": "^1.1.2",
     "phosphor-stackedpanel": "^1.0.0-beta.1",
-    "phosphor-widget": "^1.0.0-beta"
+    "phosphor-widget": "^1.0.0-beta.1"
   },
   "devDependencies": {
     "browserify": "^11.0.1",


### PR DESCRIPTION
This updates TabBar and TabPanel to make use of the new widget Title object. The user no longer needs to create their own Tab assigned to a special attached property. The widgets are simply added to the panel, and their titles manipulated as needed.

Ready for review, but not merging until tests are updated.

ping @blink1073 @dwillmer @afshin @ellisonbg @jasongrout